### PR TITLE
Update base.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,5 +5,4 @@ ipython
 psycopg2
 six
 sqlparse
-wsgiref
 django-generic-json-views


### PR DESCRIPTION
Having wsgiref in the requirements file seems to interfere up automatic deployment of requirements from pip.  It's been part of the Python stdlib since 2.5, so I suggest removing it.

There's a separate (but similar) issue with django-generic-json-views trying to pull in wsgiref as a dependency which is fixed by using a newer version than the one in PyPI.  I believe the fix for this is just to wait until PyPI is updated with the new version.
