### PR TITLE
Some changes to allow app to start within uwsgi

### DIFF
--- a/ssp_canvassing/settings/base.py
+++ b/ssp_canvassing/settings/base.py
@@ -25,7 +25,7 @@ ADMINS = (
 try:
     from .secrets import SECRET_KEY
 except ImportError:
-    print "WARNING: Please create a ssp_canvassing/settings/secrets.py file and add a SECRET_KEY"
+    print("WARNING: Please create a ssp_canvassing/settings/secrets.py file and add a SECRET_KEY")
     SECRET_KEY = 'w735l4bkg)9k_3!48it^c&f&&l)7+5fp)(768vppge!f1va)_('
 
 # SECURITY WARNING: don't run with debug turned on in production!

--- a/ssp_canvassing/settings/base.py
+++ b/ssp_canvassing/settings/base.py
@@ -23,7 +23,7 @@ ADMINS = (
 
 # SECURITY WARNING: keep the secret key used in production secret!
 try:
-    from secrets import SECRET_KEY
+    from .secrets import SECRET_KEY
 except ImportError:
     print "WARNING: Please create a ssp_canvassing/settings/secrets.py file and add a SECRET_KEY"
     SECRET_KEY = 'w735l4bkg)9k_3!48it^c&f&&l)7+5fp)(768vppge!f1va)_('
@@ -75,7 +75,7 @@ WSGI_APPLICATION = 'ssp_canvassing.wsgi.application'
 # https://docs.djangoproject.com/en/1.7/ref/settings/#databases
 
 try:
-    from secrets import DATABASES
+    from .secrets import DATABASES
 except ImportError:
     DATABASES = {
         'default': {

--- a/ssp_canvassing/settings/local.py
+++ b/ssp_canvassing/settings/local.py
@@ -1,6 +1,6 @@
 __author__ = 'scotm'
 
-from base import *
+from .base import *
 
 INSTALLED_APPS += (
     'debug_toolbar',

--- a/ssp_canvassing/settings/production.py
+++ b/ssp_canvassing/settings/production.py
@@ -4,7 +4,7 @@ import fcntl
 
 __author__ = 'scotm'
 
-from base import *
+from .base import *
 
 def get_ip_address(ifname):
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)


### PR DESCRIPTION
When specifying local or production as a settings module, Python expects relative imports for references to base.  Likewise for secrets within base.

Also, python 3 was choking on the bracket-less print statement.
